### PR TITLE
Fix broken sorting order in PluginLoader

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/plugin/PluginLoader.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/plugin/PluginLoader.java
@@ -224,13 +224,13 @@ public final class PluginLoader {
                     for (String dep : before) {
                         final Integer depIdx = idLookup.get(dep);
                         if (depIdx != null) {
-                            edges.get(depIdx).add(i);
+                            edges.get(i).add(depIdx);
                         }
                     }
                     for (String dep : after) {
                         final Integer depIdx = idLookup.get(dep);
                         if (depIdx != null) {
-                            edges.get(i).add(depIdx);
+                            edges.get(depIdx).add(i);
                         }
                     }
                 }


### PR DESCRIPTION
sortBefore() and sortAfter() behaviour was flipped due to a mistake in how the topological sort edges were set up.