### PR TITLE
Fixes for modern Minecraft

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/RfbSystemClassLoader.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/RfbSystemClassLoader.java
@@ -80,6 +80,7 @@ public final class RfbSystemClassLoader extends URLClassLoaderWithUtilities impl
                 "org.apache.logging.",
                 "org.objectweb.asm.",
                 "LZMA.",
+                "org.slf4j.",
                 "com.gtnewhorizons.retrofuturabootstrap."));
     }
 

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/ModernJavaCompatibilityPlugin.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/ModernJavaCompatibilityPlugin.java
@@ -16,7 +16,8 @@ public class ModernJavaCompatibilityPlugin implements RfbPlugin {
     public ModernJavaCompatibilityPlugin() {}
 
     public static final Logger log = LogManager.getLogger("RFB-ModernJava");
-    private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("rfb.enableModernJavaCompatibilityPlugin", "true"));
+    private static final boolean ENABLED =
+            Boolean.parseBoolean(System.getProperty("rfb.enableModernJavaCompatibilityPlugin", "true"));
 
     @Override
     public @NotNull RfbClassTransformer @Nullable [] makeTransformers() {

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/ModernJavaCompatibilityPlugin.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/ModernJavaCompatibilityPlugin.java
@@ -16,10 +16,11 @@ public class ModernJavaCompatibilityPlugin implements RfbPlugin {
     public ModernJavaCompatibilityPlugin() {}
 
     public static final Logger log = LogManager.getLogger("RFB-ModernJava");
+    private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("rfb.enableModernJavaCompatibilityPlugin", "true"));
 
     @Override
     public @NotNull RfbClassTransformer @Nullable [] makeTransformers() {
-        if (RetroFuturaBootstrap.API.javaMajorVersion() < 9) {
+        if (!ENABLED || RetroFuturaBootstrap.API.javaMajorVersion() < 9) {
             // Not needed for Java 8.
             return null;
         }

--- a/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -143,6 +143,7 @@ public class LaunchClassLoader extends URLClassLoaderWithUtilities implements Ex
                 "org.apache.logging.",
                 "org.objectweb.asm.",
                 "net.minecraft.launchwrapper.",
+                "org.slf4j.",
                 "com.gtnewhorizons.retrofuturabootstrap."));
         transformerExceptions.addAll(Arrays.asList(
                 "javax.",


### PR DESCRIPTION
These two fixes make it easier to launch modern Minecraft without needing to manually reconfigure the classloader first.

* Add SLF4J to classloader exclusions, since that is the logging interface modern MC uses. This shouldn't affect 1.7.10 since it doesn't use SLF4J.
* Add a `rfb.enableModernJavaCompatibilityPlugin` property that may be used to disable the transformations run on old classes to make them work on modern Java versions. This isn't needed for modern versions that already support Java 17+. The plugin is still enabled by default so this shouldn't break 1.7.10.