### PR TITLE
redirect all methods that can be used to set/access modifiers

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -64,6 +64,7 @@ public class UnsafeReflectionRedirector {
             throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
             setModifiers(target, value);
+            return;
         }
         field.setInt(target, value);
     }
@@ -73,6 +74,7 @@ public class UnsafeReflectionRedirector {
             throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
             setModifiers(target, value);
+            return;
         }
         field.setShort(target, value);
     }
@@ -82,6 +84,7 @@ public class UnsafeReflectionRedirector {
             throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
             setModifiers(target, value);
+            return;
         }
         field.setByte(target, value);
     }
@@ -91,6 +94,7 @@ public class UnsafeReflectionRedirector {
             throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
             setModifiers(target, value);
+            return;
         }
         field.setChar(target, value);
     }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -2,9 +2,7 @@ package com.gtnewhorizons.retrofuturabootstrap.asm;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 import sun.misc.Unsafe;
 
 /**
@@ -65,37 +63,78 @@ public class UnsafeReflectionRedirector {
     public static void setInt(Field field, Object target, int value)
             throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
-            final Field targetF = (Field) target;
-            final int actualModifiers = targetF.getModifiers();
-            if (Modifier.isStatic(actualModifiers) && Modifier.isFinal(actualModifiers)) {
-                if ((value & Modifier.FINAL) == 0) {
-                    unlockField(targetF);
-                }
-            } else {
-                targetF.setAccessible(true);
-            }
-            return;
+            setModifiers(target, value);
         }
         field.setInt(target, value);
+    }
+
+    /** {@link Field#setShort(Object, short)} */
+    public static void setShort(Field field, Object target, short value)
+            throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            setModifiers(target, value);
+        }
+        field.setShort(target, value);
+    }
+
+    /** {@link Field#setByte(Object, byte)} */
+    public static void setByte(Field field, Object target, byte value)
+            throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            setModifiers(target, value);
+        }
+        field.setByte(target, value);
+    }
+
+    /** {@link Field#setChar(Object, char)} */
+    public static void setChar(Field field, Object target, char value)
+            throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            setModifiers(target, value);
+        }
+        field.setChar(target, value);
     }
 
     /** {@link Field#getInt(Object)} */
     public static int getInt(Field field, Object target) throws IllegalArgumentException, IllegalAccessException {
         if (field == fieldModifiers) {
-            final Field targetF = (Field) target;
-            final boolean isUnlocked = isFieldUnlocked(targetF);
-            int modifiers = targetF.getModifiers();
-            if (isUnlocked) {
-                modifiers &= ~Modifier.FINAL;
-            }
-            return modifiers;
+            return getModifiers(target);
         }
         return field.getInt(target);
+    }
+
+    /** {@link Field#getLong(Object)} */
+    public static long getLong(Field field, Object target) throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            return getModifiers(target);
+        }
+        return field.getLong(target);
+    }
+
+    /** {@link Field#getFloat(Object)} */
+    public static float getFloat(Field field, Object target) throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            return getModifiers(target);
+        }
+        return field.getFloat(target);
+    }
+
+    /** {@link Field#getDouble(Object)} */
+    public static double getDouble(Field field, Object target) throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            return getModifiers(target);
+        }
+        return field.getDouble(target);
     }
 
     /** {@link Field#set(Object, Object)} */
     public static void set(Field field, Object target, Object value)
             throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers && canCoerceToInt(value)) {
+            setModifiers(target, coerceToInt(value));
+            return;
+        }
+
         if (isFieldUnlocked(field)) {
             // Only static final fields are redirected to Unsafe.
             if (!Modifier.isStatic(field.getModifiers())) {
@@ -111,5 +150,49 @@ public class UnsafeReflectionRedirector {
         } else {
             field.set(target, value);
         }
+    }
+
+    /** {@link Field#get(Object)} */
+    public static Object get(Field field, Object target) throws IllegalArgumentException, IllegalAccessException {
+        if (field == fieldModifiers) {
+            return getModifiers(target);
+        }
+        return field.get(target);
+    }
+
+    private static int coerceToInt(Object obj) {
+        if (obj instanceof Number) {
+            return ((Number) obj).intValue();
+        } else if (obj instanceof Character) {
+            return (Character) obj;
+        } else {
+            throw new IllegalArgumentException("Passed non-integer-coerceable value to coerceToInt: " + obj);
+        }
+    }
+
+    private static boolean canCoerceToInt(Object obj) {
+        return obj instanceof Byte || obj instanceof Short || obj instanceof Integer || obj instanceof Character;
+    }
+
+    private static void setModifiers(Object target, int value) {
+        final Field targetF = (Field) target;
+        final int actualModifiers = targetF.getModifiers();
+        if (Modifier.isStatic(actualModifiers) && Modifier.isFinal(actualModifiers)) {
+            if ((value & Modifier.FINAL) == 0) {
+                unlockField(targetF);
+            }
+        } else {
+            targetF.setAccessible(true);
+        }
+    }
+
+    private static int getModifiers(Object target) {
+        final Field targetF = (Field) target;
+        final boolean isUnlocked = isFieldUnlocked(targetF);
+        int modifiers = targetF.getModifiers();
+        if (isUnlocked) {
+            modifiers &= ~Modifier.FINAL;
+        }
+        return modifiers;
     }
 }

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
@@ -42,6 +42,7 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
     final Set<String> REDIRECT_FIELD_METHODS = new HashSet<>();
 
     {
+        // Redirect set methods with a type that can be coerced to int, and get methods with types int can be coerced to
         REDIRECT_FIELD_METHODS.addAll(Arrays.asList(
                 "setInt(Ljava/lang/Object;I)V",
                 "setByte(Ljava/lang/Object;B)V",


### PR DESCRIPTION
Java's reflection set/get methods obey the same implicit coercion rules used by native types and their boxed equivalents. This means that many methods other than `setInt` can be used to set the `modifiers` field, and the same applies to getting it, requiring those to be redirected as well.