### PR TITLE
interface metadata and non-classloading getCommonSuperClass

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
@@ -3,6 +3,9 @@ package com.gtnewhorizons.retrofuturabootstrap.api;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,7 +32,8 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
     public final int @NotNull [] interfaceIndices;
     public final @NotNull String binaryThisName;
     public final @Nullable String binarySuperName;
-    public final String @NotNull [] binaryInterfaceNames;
+    /** List is unmodifiable */
+    public final @NotNull List<@NotNull String> binaryInterfaceNames;
 
     /**
      * Attempts to parse a class header.
@@ -68,7 +72,7 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
         this.superClassIndex = u16(bytes, cpOff + Offsets.pastCpSuperClassU16);
         this.interfacesCount = u16(bytes, cpOff + Offsets.pastCpInterfacesCountU16);
         this.interfaceIndices = new int[this.interfacesCount];
-        this.binaryInterfaceNames = new String[this.interfacesCount];
+        List<String> interfaceNames = new ArrayList<>(this.interfacesCount);
 
         // Parse this&super names
         if (constantPoolEntryTypes[thisClassIndex - 1] != ConstantPoolEntryTypes.Class) {
@@ -108,8 +112,9 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
                     modifiedUtf8(bytes, constantPoolEntryOffsets[interfaceNameIndex - 1] + 1);
 
             this.interfaceIndices[i] = interfaceIndex;
-            this.binaryInterfaceNames[i] = binaryInterfaceName;
+            interfaceNames.add(binaryInterfaceName);
         }
+        this.binaryInterfaceNames = Collections.unmodifiableList(interfaceNames);
     }
 
     /** Helpers to read big-endian values from class files. */
@@ -363,7 +368,7 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
     }
 
     @Override
-    public String @NotNull [] binaryInterfaceNames() {
+    public @NotNull List<@NotNull String> binaryInterfaceNames() {
         return binaryInterfaceNames;
     }
 }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/FastClassAccessor.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/FastClassAccessor.java
@@ -31,6 +31,8 @@ public interface FastClassAccessor {
     @Nullable
     String binarySuperName();
 
+    String @NotNull [] binaryInterfaceNames();
+
     static OfLoaded ofLoaded(Class<?> loadedClass) {
         return new OfLoaded(loadedClass);
     }
@@ -95,6 +97,11 @@ public interface FastClassAccessor {
         public @Nullable String binarySuperName() {
             return handle.superName;
         }
+
+        @Override
+        public String @NotNull [] binaryInterfaceNames() {
+            return handle.interfaces == null ? new String[0] : handle.interfaces.toArray(new String[0]);
+        }
     }
 
     final class OfLoaded implements FastClassAccessor {
@@ -153,6 +160,16 @@ public interface FastClassAccessor {
         public @Nullable String binarySuperName() {
             final Class<?> superclass = handle.getSuperclass();
             return superclass == null ? null : superclass.getName().replace('.', '/');
+        }
+
+        @Override
+        public String @NotNull [] binaryInterfaceNames() {
+            Class<?>[] interfaces = handle.getInterfaces();
+            String[] binaryInterfaceNames = new String[interfaces.length];
+            for (int i = 0; i < interfaces.length; i++) {
+                binaryInterfaceNames[i] = interfaces[i].getName().replace('.', '/');
+            }
+            return binaryInterfaceNames;
         }
     }
 }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/SafeAsmClassWriter.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/SafeAsmClassWriter.java
@@ -3,6 +3,10 @@ package com.gtnewhorizons.retrofuturabootstrap.asm;
 import com.gtnewhorizons.retrofuturabootstrap.Main;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
+import com.gtnewhorizons.retrofuturabootstrap.api.FastClassAccessor;
+import java.util.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
@@ -12,6 +16,7 @@ import org.objectweb.asm.ClassWriter;
 public class SafeAsmClassWriter extends ClassWriter {
     public static final ThreadLocal<Integer> forcedFlags = ThreadLocal.withInitial(() -> 0);
     public static final ThreadLocal<byte[]> forcedOriginalClass = new ThreadLocal<>();
+    private final Map<String, InheritanceNode> inheritanceCache = new HashMap<>();
 
     public SafeAsmClassWriter(int flags) {
         super(flags | forcedFlags.get());
@@ -30,5 +35,114 @@ public class SafeAsmClassWriter extends ClassWriter {
     protected ClassLoader getClassLoader() {
         final ExtensibleClassLoader launchLoader = Main.launchLoader;
         return launchLoader != null ? launchLoader.asURLClassLoader() : Main.compatLoader;
+    }
+
+    @Override
+    protected String getCommonSuperClass(String type1, String type2) {
+        ClassLoader classLoader = getClassLoader();
+        if (!(classLoader instanceof ExtensibleClassLoader)) {
+            Main.logger.warn(
+                    "SafeAsmClassWriter#getClassLoader() didn't return an ExtensibleClassLoader, falling back to default getCommonSuperClass implementation");
+            return super.getCommonSuperClass(type1, type2);
+        }
+        ExtensibleClassLoader loader = (ExtensibleClassLoader) classLoader;
+
+        // Crash if types aren't real
+        InheritanceNode inheritance1 = getInheritanceInfo(loader, type1);
+        if (inheritance1 == null) {
+            throw new TypeNotPresentException(type1, null);
+        }
+
+        InheritanceNode inheritance2 = getInheritanceInfo(loader, type2);
+        if (inheritance2 == null) {
+            throw new TypeNotPresentException(type2, null);
+        }
+
+        // Assignable checks, replicates the ones in asm
+        if (inheritance1.isAssignableFrom(inheritance2)) {
+            return type1;
+        }
+        if (inheritance2.isAssignableFrom(inheritance1)) {
+            return type2;
+        }
+
+        // this is a bit weird but it's what ASM does
+        if (inheritance1.accessor.isInterface() || inheritance2.accessor.isInterface()) {
+            return "java/lang/Object";
+        } else {
+            do {
+                inheritance1 = inheritance1.superClass;
+                // We might have some cut-off inheritance trees that don't properly reach back to Object. Avoid crashing
+                // on those.
+                if (inheritance1 == null) {
+                    return "java/lang/Object";
+                }
+            } while (!inheritance1.isAssignableFrom(inheritance2));
+            return inheritance1.accessor.binaryThisName();
+        }
+    }
+
+    private @Nullable InheritanceNode getInheritanceInfo(ExtensibleClassLoader loader, String type) {
+        InheritanceNode node = inheritanceCache.get(type);
+        if (node == null) {
+            FastClassAccessor typeAccessor = loader.findClassMetadata(type.replace('/', '.'));
+            if (typeAccessor == null) {
+                Main.logger.warn("Could not find type {} during inheritance search", type);
+                return null;
+            }
+
+            Set<InheritanceNode> allSuperClasses = new HashSet<>();
+            String superType = typeAccessor.binarySuperName();
+            InheritanceNode superClass;
+            // account for Object
+            if (superType != null) {
+                superClass = getInheritanceInfo(loader, superType);
+                if (superClass != null) {
+                    allSuperClasses.addAll(superClass.allSuperClasses);
+                }
+            } else {
+                superClass = null;
+            }
+
+            List<InheritanceNode> interfaces = new ArrayList<>();
+            for (String interfaceType : typeAccessor.binaryInterfaceNames()) {
+                InheritanceNode iface = getInheritanceInfo(loader, interfaceType);
+                if (iface != null) {
+                    interfaces.add(iface);
+                    allSuperClasses.addAll(iface.allSuperClasses);
+                }
+            }
+
+            node = new InheritanceNode(typeAccessor, superClass, interfaces, allSuperClasses);
+            inheritanceCache.put(type, node);
+        }
+        return node;
+    }
+
+    /**
+     * Some inheritance metadata. Can be compared with == as long as they're from the same ClassWriter because of caching.
+     */
+    private static class InheritanceNode {
+        final @Nullable InheritanceNode superClass;
+        final @NotNull List<InheritanceNode> interfaces;
+        final @NotNull FastClassAccessor accessor;
+        // For quick isAssignableFrom checks
+        final @NotNull Set<InheritanceNode> allSuperClasses;
+
+        InheritanceNode(
+                @NotNull FastClassAccessor accessor,
+                @Nullable InheritanceNode superClass,
+                @NotNull List<InheritanceNode> interfaces,
+                @NotNull Set<InheritanceNode> allSuperClasses) {
+            this.accessor = accessor;
+            this.superClass = superClass;
+            this.interfaces = interfaces;
+            this.allSuperClasses = allSuperClasses;
+            allSuperClasses.add(this);
+        }
+
+        boolean isAssignableFrom(InheritanceNode other) {
+            return other.allSuperClasses.contains(this);
+        }
     }
 }


### PR DESCRIPTION
Implements reading interface metadata in `ClassHeaderMetadata`, and uses this metadata in the implementation of a `getCommonSuperClass` method that does not require loading classes. Should prevent a decent chunk of weird classloading issues arising from mods that use `ClassWriter.COMPUTE_FRAMES`.