### PR TITLE
Fix CCL crash on 1.12

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -151,6 +151,8 @@ public class UnsafeReflectionRedirector {
             final long staticOffset = unsafe.staticFieldOffset(field);
             final Object staticObject = unsafe.staticFieldBase(field);
             unsafe.putObjectVolatile(staticObject, staticOffset, value);
+        } else if (target instanceof Dummy && value instanceof Field) { // Do nothing if trying to cast Field to Dummy$modifiers
+            return;
         } else {
             field.set(target, value);
         }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -151,7 +151,8 @@ public class UnsafeReflectionRedirector {
             final long staticOffset = unsafe.staticFieldOffset(field);
             final Object staticObject = unsafe.staticFieldBase(field);
             unsafe.putObjectVolatile(staticObject, staticOffset, value);
-        } else if (target instanceof Dummy && value instanceof Field) { // Do nothing if trying to cast Field to Dummy$modifiers
+        } else if (target instanceof Dummy
+                && value instanceof Field) { // Do nothing if trying to cast Field to Dummy$modifiers
             return;
         } else {
             field.set(target, value);


### PR DESCRIPTION
This PR fixes CCL and likely some other mods using a similar way to remove final modifier on 1.12 by doing nothing if they try to set Dummy$modifiers to Field.