### PR TITLE
Fix registerTransformer not working

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -163,7 +163,12 @@ public class LaunchClassLoader extends URLClassLoaderWithUtilities implements Ex
      */
     public void registerTransformer(String transformerClassName) {
         try {
-            Class<?> xformerClass = Class.forName(transformerClassName, true, this);
+            Class<?> xformerClass;
+            if (Main.launchLoader != null) {
+                xformerClass = Main.launchLoader.findClass(transformerClassName);
+            } else {
+                xformerClass = Class.forName(transformerClassName, true, this);
+            }
             if (!IClassTransformer.class.isAssignableFrom(xformerClass)) {
                 LogWrapper.severe(
                         "Tried to register a transformer {} which does not implement IClassTransformer",


### PR DESCRIPTION
Fixes registerTransformer not working/finding the transformer class by using `launchLoader.findClass()` to load the class, if launchLoader is null it'll fallback to `Class.forName()` (Not sure if this is even needed)