### PR TITLE
Add a public API for finding transformers by ID and guarantee exclusions mutability.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/RfbClassTransformerHandle.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/RfbClassTransformerHandle.java
@@ -100,7 +100,7 @@ public final class RfbClassTransformerHandle {
     }
 
     /**
-     * @return List of class name prefixes associated with this transformer.
+     * @return List of class name prefixes associated with this transformer. Guaranteed to be mutable.
      */
     public @NotNull List<@NotNull String> exclusions() {
         return exclusions;

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/RfbPluginHandle.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/RfbPluginHandle.java
@@ -1,6 +1,13 @@
 package com.gtnewhorizons.retrofuturabootstrap.api;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A handle to a {@link RfbPlugin} with its associated metadata.
@@ -8,10 +15,16 @@ import org.jetbrains.annotations.NotNull;
 public class RfbPluginHandle {
     private final @NotNull RfbPluginMetadata metadata;
     private final @NotNull RfbPlugin plugin;
+    private final @NotNull List<RfbClassTransformerHandle> transformers;
+    private final @NotNull List<RfbClassTransformerHandle> transformersView;
+    private final @NotNull Map<String, RfbClassTransformerHandle> transformersNameMap;
 
     public RfbPluginHandle(@NotNull RfbPluginMetadata metadata, @NotNull RfbPlugin plugin) {
         this.metadata = metadata;
         this.plugin = plugin;
+        this.transformers = new ArrayList<>(4);
+        this.transformersView = Collections.unmodifiableList(transformers);
+        this.transformersNameMap = new HashMap<>(4);
     }
 
     /**
@@ -26,5 +39,38 @@ public class RfbPluginHandle {
      */
     public @NotNull RfbPlugin plugin() {
         return plugin;
+    }
+
+    /**
+     * @return The list of currently constructed transformers that were registered by this plugin. Cannot be mutated.
+     */
+    public @NotNull List<RfbClassTransformerHandle> transformers() {
+        return transformersView;
+    }
+
+    /**
+     * @param id The transformer ID to look for, without the plugin ID (e.g. {@code "redirect"} if looking for {@code "lwjgl3ify:redirect"})
+     * @return The transformer that matches the given ID, or {@code null} if not found.
+     */
+    public @Nullable RfbClassTransformerHandle findTransformerById(@NotNull String id) {
+        return transformersNameMap.get(id);
+    }
+
+    /**
+     * Mostly for internal use, used to register a newly constructed transformer with the plugin that requested it.
+     * @param handle The handle of the transformer to register
+     */
+    public void registerAdditionalTransformer(@NotNull RfbClassTransformerHandle handle) {
+        Objects.requireNonNull(handle);
+        if (handle.plugin() != plugin) {
+            throw new IllegalArgumentException(
+                    "Trying to add a transformer " + handle.id() + " to mismatched plugin " + metadata.id());
+        }
+        final RfbClassTransformer xformer = handle.transformer();
+        if (transformersNameMap.putIfAbsent(xformer.id(), handle) != null) {
+            throw new IllegalArgumentException(
+                    "Trying to register a transformer with a duplicate name: " + handle.id());
+        }
+        transformers.add(handle);
     }
 }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/plugin/PluginLoader.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/plugin/PluginLoader.java
@@ -126,6 +126,7 @@ public final class PluginLoader {
                             .collect(Collectors.toList());
                     Main.mutateRfbTransformers(list -> list.addAll(toAdd));
                     for (RfbClassTransformerHandle newlyRegistered : toAdd) {
+                        handle.registerAdditionalTransformer(newlyRegistered);
                         newlyRegistered.transformer().onRegistration(Objects.requireNonNull(Main.compatLoader));
                         newlyRegistered.transformer().onRegistration(Objects.requireNonNull(Main.launchLoader));
                     }
@@ -179,6 +180,7 @@ public final class PluginLoader {
                             new RfbClassTransformerHandle(handle.metadata(), handle.plugin(), xformer);
                     newTransformers.add(xhandle);
                     toRegister.add(xhandle);
+                    handle.registerAdditionalTransformer(xhandle);
                 }
             }
             final String[] emptyStrA = new String[0];


### PR DESCRIPTION
Explicitly allow adding new exclusions to RFB class transformers by ID in the public API.
As requested by @embeddedt.