### PR TITLE
correct unsafe reflection redirector to use caller class's permissions

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -10,7 +10,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.jetbrains.annotations.NotNull;
 import sun.misc.Unsafe;
 
@@ -105,7 +104,8 @@ public class UnsafeReflectionRedirector {
         String name;
         MethodType shape;
         if (type.isPrimitive()) {
-            name = "put" + Character.toUpperCase(type.getName().charAt(0)) + type.getName().substring(1) + "Volatile";
+            name = "put" + Character.toUpperCase(type.getName().charAt(0))
+                    + type.getName().substring(1) + "Volatile";
             shape = MethodType.methodType(void.class, Object.class, long.class, type);
         } else {
             name = "putObjectVolatile";
@@ -117,7 +117,7 @@ public class UnsafeReflectionRedirector {
     }
 
     private static Accessors getAccessors(MethodHandles.Lookup caller, Field field) throws Throwable {
-		Map<Field, Accessors> forClass = fieldAccessors.get(caller.lookupClass());
+        Map<Field, Accessors> forClass = fieldAccessors.get(caller.lookupClass());
         Accessors accessors = forClass.get(field);
         if (accessors == null) {
             accessors = new Accessors(caller, field);
@@ -147,8 +147,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Field#setInt(Object, int)} */
-    private static void setInt(MethodHandles.Lookup caller, Field field, Object target, int value)
-            throws Throwable {
+    private static void setInt(MethodHandles.Lookup caller, Field field, Object target, int value) throws Throwable {
         if (field == fieldModifiers) {
             setModifiers(caller, target, value);
             return;
@@ -167,8 +166,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Field#setByte(Object, byte)} */
-    private static void setByte(MethodHandles.Lookup caller, Field field, Object target, byte value)
-            throws Throwable {
+    private static void setByte(MethodHandles.Lookup caller, Field field, Object target, byte value) throws Throwable {
         if (field == fieldModifiers) {
             setModifiers(caller, target, value);
             return;
@@ -177,8 +175,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Field#setChar(Object, char)} */
-    private static void setChar(MethodHandles.Lookup caller, Field field, Object target, char value)
-            throws Throwable {
+    private static void setChar(MethodHandles.Lookup caller, Field field, Object target, char value) throws Throwable {
         if (field == fieldModifiers) {
             setModifiers(caller, target, value);
             return;
@@ -219,8 +216,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Field#set(Object, Object)} */
-    private static void set(MethodHandles.Lookup caller, Field field, Object target, Object value)
-            throws Throwable {
+    private static void set(MethodHandles.Lookup caller, Field field, Object target, Object value) throws Throwable {
         if (field == fieldModifiers && canCoerceToInt(value)) {
             setModifiers(caller, target, coerceToInt(value));
             return;
@@ -264,7 +260,7 @@ public class UnsafeReflectionRedirector {
 
     private static int getModifiers(MethodHandles.Lookup caller, Object target) throws Throwable {
         final Field targetF = (Field) target;
-		int modifiers = targetF.getModifiers();
+        int modifiers = targetF.getModifiers();
         if (getAccessors(caller, targetF).isUnlocked()) {
             modifiers &= ~Modifier.FINAL;
         }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -112,8 +112,10 @@ public class UnsafeReflectionRedirector {
             shape = MethodType.methodType(void.class, Object.class, long.class, Object.class);
         }
 
-        MethodHandle mh = self.findVirtual(Unsafe.class, name, shape).bindTo(unsafe);
-        return MethodHandles.insertArguments(mh, 1, base, off);
+        MethodHandle mh = self.findVirtual(Unsafe.class, name, shape);
+        mh = MethodHandles.insertArguments(mh, 0, unsafe, base, off);
+        mh = MethodHandles.dropArguments(mh, 0, Object.class);
+        return mh.asType(MethodType.methodType(void.class, Object.class, type));
     }
 
     private static Accessors getAccessors(MethodHandles.Lookup caller, Field field) throws Throwable {

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -127,7 +127,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Class#getDeclaredField(String)} */
-    private static Field getDeclaredField(Class<?> klass, String name) throws NoSuchFieldException, SecurityException {
+    public static Field getDeclaredField(Class<?> klass, String name) throws NoSuchFieldException, SecurityException {
         if (klass == fieldClass) {
             if ("modifiers".equals(name)) {
                 return fieldModifiers;
@@ -139,7 +139,7 @@ public class UnsafeReflectionRedirector {
     }
 
     /** {@link Class#getDeclaredFields()} */
-    private static Field[] getDeclaredFields(Class<?> klass) throws SecurityException {
+    public static Field[] getDeclaredFields(Class<?> klass) throws SecurityException {
         if (klass == fieldClass) {
             return new Field[] {fieldModifiers};
         }

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/asm/UnsafeReflectionRedirector.java
@@ -28,10 +28,9 @@ public class UnsafeReflectionRedirector {
     private static final MethodHandles.Lookup self = MethodHandles.lookup();
     private static final Unsafe unsafe;
 
-    private static final ClassValue<ConcurrentHashMap<Field, Accessors>> fieldAccessors =
-            new ClassValue<ConcurrentHashMap<Field, Accessors>>() {
+    private static final ClassValue<Map<Field, Accessors>> fieldAccessors = new ClassValue<Map<Field, Accessors>>() {
         @Override
-        protected ConcurrentHashMap<Field, Accessors> computeValue(@NotNull Class<?> type) {
+        protected Map<Field, Accessors> computeValue(@NotNull Class<?> type) {
             return new ConcurrentHashMap<>();
         }
     };

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
@@ -106,14 +106,15 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
                             && REDIRECT_FIELD_METHODS.contains(insn.name + insn.desc)) {
                         // add a Field argument at the start
                         String newDesc = "(Ljava/lang/reflect/Field;" + insn.desc.substring(1);
-                        InvokeDynamicInsnNode newNode =
-                                new InvokeDynamicInsnNode(insn.name, newDesc, new Handle(
+                        InvokeDynamicInsnNode newNode = new InvokeDynamicInsnNode(
+                                insn.name,
+                                newDesc,
+                                new Handle(
                                         Opcodes.H_INVOKESTATIC,
                                         REDIRECTION_NAME,
                                         "bsm",
                                         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
-                                        false
-                                ));
+                                        false));
                         method.instructions.set(insn, newNode);
                         node.version = Math.max(node.version, Opcodes.V1_7); // invokedynamic requires at least Java 7
                         classNode.computeFrames();

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
@@ -13,12 +13,8 @@ import java.util.jar.Manifest;
 import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.*;
+import org.objectweb.asm.tree.*;
 
 /**
  * Replaces the broken "remove final from Field.modifiers" approach with a redirection to our Unsafe-based method.
@@ -110,9 +106,17 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
                             && REDIRECT_FIELD_METHODS.contains(insn.name + insn.desc)) {
                         // add a Field argument at the start
                         String newDesc = "(Ljava/lang/reflect/Field;" + insn.desc.substring(1);
-                        insn.setOpcode(Opcodes.INVOKESTATIC);
-                        insn.owner = REDIRECTION_NAME;
-                        insn.desc = newDesc;
+                        InvokeDynamicInsnNode newNode =
+                                new InvokeDynamicInsnNode(insn.name, newDesc, new Handle(
+                                        Opcodes.H_INVOKESTATIC,
+                                        REDIRECTION_NAME,
+                                        "bsm",
+                                        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                        false
+                                ));
+                        method.instructions.set(insn, newNode);
+                        node.version = Math.max(node.version, Opcodes.V1_7); // invokedynamic requires at least Java 7
+                        classNode.computeFrames();
                     }
                 }
             }


### PR DESCRIPTION
in cases like this:
```java
class MyClass {
	private boolean b;
	void die() throws Throwable {
		getClass().getDeclaredField("b").set(this, true);
	}
}
```

`set` would be redirected, but `UnsafeReflectionRedirector` wouldn't have access to `MyClass.b` via the `Field` object passed. For example, this happens when running the mod [PolyCrosshair](https://github.com/Polyfrost/PolyCrosshair/blob/main/src/main/kotlin/org/polyfrost/crosshair/config/CrosshairEntry.kt#L43).

this PR replaces the redirection with one that uses an `invokedynamic` bootstrap, which allows the redirector to get a `MethodHandles.Lookup` object with the permissions of the class containing the indy. It then makes handles to the getters/setters of that field and caches then in a `ClassValue`. This should also be in theory marginally more performant than the old core reflection implementation because access checks are only performed once.

i haven't tested this in 1.7.10, but the 1.8.9 instance that previously crashed now boots.