### PR TITLE
Fix  `cfgDumpLoadedClassesPerTransformer` activating with `legacy.debugClassLoadingSave` instead of `legacy.debugClassLoadingFiner`

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
@@ -24,7 +24,8 @@ public class SharedConfig {
             || Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingSave", "false"));
 
     /** Controlled by system property {@code rfb.dumpLoadedClassesPerTransformer=false}, whether loaded classes should be dumped to RFB_CLASS_DUMP/, with a file per asm transformer */
-    public static final boolean cfgDumpLoadedClassesPerTransformer = getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false);
+    public static final boolean cfgDumpLoadedClassesPerTransformer =
+            getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false);
 
     /** Controlled by system property {@code rfb.dumpClassesAsynchronously=true}, if the class dumps are done from another Thread to avoid slow IO */
     public static final boolean cfgDumpClassesAsynchronously = getBooleanOr("rfb.dumpClassesAsynchronously", true);

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
@@ -24,9 +24,7 @@ public class SharedConfig {
             || Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingSave", "false"));
 
     /** Controlled by system property {@code rfb.dumpLoadedClassesPerTransformer=false}, whether loaded classes should be dumped to RFB_CLASS_DUMP/, with a file per asm transformer */
-    public static final boolean cfgDumpLoadedClassesPerTransformer =
-            getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false)
-                    || Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingSave", "false"));
+    public static final boolean cfgDumpLoadedClassesPerTransformer = getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false);
 
     /** Controlled by system property {@code rfb.dumpClassesAsynchronously=true}, if the class dumps are done from another Thread to avoid slow IO */
     public static final boolean cfgDumpClassesAsynchronously = getBooleanOr("rfb.dumpClassesAsynchronously", true);

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/SharedConfig.java
@@ -25,7 +25,8 @@ public class SharedConfig {
 
     /** Controlled by system property {@code rfb.dumpLoadedClassesPerTransformer=false}, whether loaded classes should be dumped to RFB_CLASS_DUMP/, with a file per asm transformer */
     public static final boolean cfgDumpLoadedClassesPerTransformer =
-            getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false);
+            getBooleanOr("rfb.dumpLoadedClassesPerTransformer", false)
+                    || Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingFiner", "false"));
 
     /** Controlled by system property {@code rfb.dumpClassesAsynchronously=true}, if the class dumps are done from another Thread to avoid slow IO */
     public static final boolean cfgDumpClassesAsynchronously = getBooleanOr("rfb.dumpClassesAsynchronously", true);


### PR DESCRIPTION
Currently when you use `-Dlegacy.debugClassLoadingSave=true` with RFB it will save the transformed classes between each transformer step, this is a bug because it should only happen when you have the special flag `-Drfb.dumpLoadedClassesPerTransformer=true`