### PR TITLE
Optimize shouldTransformClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 out/
 
 .DS_Store
+.idea

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/BytePatternMatcher.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/BytePatternMatcher.java
@@ -1,0 +1,142 @@
+package com.gtnewhorizons.retrofuturabootstrap.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class BytePatternMatcher {
+    final Mode mode;
+    // first byte -> matched patterns
+    final byte[][][] byFirst = new byte[256][][];
+    int minPatternLen = Integer.MAX_VALUE;
+
+    public enum Mode {
+        /** Checks if the constant pool entry contains a pattern */
+        Contains,
+        /** Checks if the whole constant pool entry equals a pattern */
+        Equals,
+        /** Checks if the constant pool entry starts with a pattern */
+        StartsWith
+    }
+
+    public BytePatternMatcher(String strPattern, Mode mode) {
+        this(new String[] {strPattern}, mode);
+    }
+
+    public BytePatternMatcher(String[] strPatterns, Mode mode) {
+        this.mode = mode;
+
+        final byte[][] patterns = new byte[strPatterns.length][];
+        final int[] bucketSizes = new int[256];
+        final int[] bucketIndices = new int[Math.min(strPatterns.length, 256)];
+        int bucketsCount = 0;
+
+        for (int i = 0; i < strPatterns.length; i++) {
+            final byte[] pattern = strPatterns[i].getBytes(StandardCharsets.UTF_8);
+            patterns[i] = pattern;
+
+            if (pattern.length < minPatternLen) {
+                minPatternLen = pattern.length;
+            }
+
+            final int bucketIndex = pattern[0] & 0xFF;
+            if (bucketSizes[bucketIndex]++ == 0) {
+                bucketIndices[bucketsCount++] = bucketIndex;
+            }
+        }
+
+        // Ascending sorting by length
+        Arrays.sort(patterns, (a, b) -> Integer.compare(a.length, b.length));
+
+        for (int i = 0; i < bucketsCount; i++) {
+            final int bucketIndex = bucketIndices[i];
+            byFirst[bucketIndex] = new byte[bucketSizes[bucketIndex]][];
+            bucketSizes[bucketIndex] = 0; // reuse as write index
+        }
+
+        for (final byte[] pattern : patterns) {
+            final int bucketIndex = pattern[0] & 0xFF;
+            byFirst[bucketIndex][bucketSizes[bucketIndex]++] = pattern;
+        }
+    }
+
+    public boolean matches(byte[] bytes, int start, int len) {
+        if (len < minPatternLen) {
+            return false;
+        }
+
+        switch (mode) {
+            case Contains:
+                return contains(bytes, start, len);
+            case Equals:
+                return equals(bytes, start, len);
+            case StartsWith:
+                return startsWith(bytes, start, len);
+        }
+
+        return false;
+    }
+
+    private boolean contains(byte[] bytes, int start, int len) {
+        final int end = start + len;
+
+        for (int pos = start; pos <= end - minPatternLen; pos++) {
+            final byte[][] patterns = byFirst[bytes[pos] & 0xFF];
+            if (patterns == null) {
+                continue;
+            }
+
+            for (final byte[] pattern : patterns) {
+                if (pattern.length > end - pos) {
+                    break;
+                }
+
+                int k = pattern.length - 1;
+                while (k > 0 && bytes[pos + k] == pattern[k]) k--;
+                if (k == 0) return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean equals(byte[] bytes, int start, int len) {
+        final byte[][] patterns = byFirst[bytes[start] & 0xFF];
+        if (patterns == null) {
+            return false;
+        }
+
+        for (final byte[] pattern : patterns) {
+            if (pattern.length < len) {
+                continue;
+            }
+            if (pattern.length > len) {
+                break;
+            }
+
+            int k = pattern.length - 1;
+            while (k > 0 && bytes[start + k] == pattern[k]) k--;
+            if (k == 0) return true;
+        }
+
+        return false;
+    }
+
+    private boolean startsWith(byte[] bytes, int start, int len) {
+        final byte[][] patterns = byFirst[bytes[start] & 0xFF];
+        if (patterns == null) {
+            return false;
+        }
+
+        for (final byte[] pattern : patterns) {
+            if (pattern.length > len) {
+                break;
+            }
+
+            int k = pattern.length - 1;
+            while (k > 0 && bytes[start + k] == pattern[k]) k--;
+            if (k == 0) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/BytePatternMatcher.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/BytePatternMatcher.java
@@ -3,11 +3,11 @@ package com.gtnewhorizons.retrofuturabootstrap.api;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-public class BytePatternMatcher {
-    final Mode mode;
+public final class BytePatternMatcher {
+    private final Mode mode;
     // first byte -> matched patterns
-    final byte[][][] byFirst = new byte[256][][];
-    int minPatternLen = Integer.MAX_VALUE;
+    private final byte[][][] byFirst = new byte[256][][];
+    private int minPatternLen = Integer.MAX_VALUE;
 
     public enum Mode {
         /** Checks if the constant pool entry contains a pattern */

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
@@ -17,10 +17,8 @@ import org.objectweb.asm.Opcodes;
  */
 public final class ClassHeaderMetadata implements FastClassAccessor {
 
-    public final byte[] classBytes;
     public final int minorVersion;
     public final int majorVersion;
-
     public final int constantPoolEntryCount;
     /** Byte offsets of where each constant pool entry starts (index of the tag byte), zero-indexed! */
     public final int @NotNull [] constantPoolEntryOffsets;
@@ -50,7 +48,6 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
         if (!isValidClass(bytes)) {
             throw new IllegalArgumentException("Invalid class detected");
         }
-        this.classBytes = bytes;
         this.minorVersion = u16(bytes, Offsets.minorVersionU16);
         this.majorVersion = u16(bytes, Offsets.majorVersionU16);
         this.constantPoolEntryCount = u16(bytes, Offsets.constantPoolCountU16);
@@ -322,7 +319,7 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
      * @param matcher A configured byte matcher with patterns to search for.
      * @return {@code true} if there is a match for at least one constant pool entry.
      */
-    public boolean matchesBytes(final BytePatternMatcher matcher) {
+    public boolean matchesBytes(final byte[] classBytes, final BytePatternMatcher matcher) {
         for (final int offset : constantPoolUtf8EntryOffsets) {
             // first byte is entry type, second and third bytes are length
             final int length = u16(classBytes, offset + 1);

--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassHeaderMetadata.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.jetbrains.annotations.Contract;
@@ -16,11 +17,15 @@ import org.objectweb.asm.Opcodes;
  */
 public final class ClassHeaderMetadata implements FastClassAccessor {
 
+    public final byte[] classBytes;
     public final int minorVersion;
     public final int majorVersion;
+
     public final int constantPoolEntryCount;
     /** Byte offsets of where each constant pool entry starts (index of the tag byte), zero-indexed! */
     public final int @NotNull [] constantPoolEntryOffsets;
+    /** Approximately only half of the entries are utf-8, so this array can be used to iterate over them more quickly */
+    public final int @NotNull [] constantPoolUtf8EntryOffsets;
     /** Type of each parsed constant pool entry, zero-indexed! */
     public final ConstantPoolEntryTypes @NotNull [] constantPoolEntryTypes;
 
@@ -45,15 +50,17 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
         if (!isValidClass(bytes)) {
             throw new IllegalArgumentException("Invalid class detected");
         }
+        this.classBytes = bytes;
         this.minorVersion = u16(bytes, Offsets.minorVersionU16);
         this.majorVersion = u16(bytes, Offsets.majorVersionU16);
         this.constantPoolEntryCount = u16(bytes, Offsets.constantPoolCountU16);
         this.constantPoolEntryOffsets = new int[constantPoolEntryCount];
         this.constantPoolEntryTypes = new ConstantPoolEntryTypes[constantPoolEntryCount];
         // scan through CP entries
-        final int cpOff;
         {
             int off = Offsets.constantPoolStart;
+            final int[] utf8EntryOffsets = new int[constantPoolEntryCount];
+            int utf8Entries = 0;
             for (int entry = 0; entry < constantPoolEntryCount - 1; entry++) {
                 constantPoolEntryOffsets[entry] = off;
                 ConstantPoolEntryTypes type = ConstantPoolEntryTypes.parse(bytes, off);
@@ -65,18 +72,18 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
                     constantPoolEntryTypes[entry] = type;
                 } else if (type == ConstantPoolEntryTypes.InvokeDynamic) {
                     hasInvokeDynamicEntry = true;
+                } else if (type == ConstantPoolEntryTypes.Utf8) {
+                    utf8EntryOffsets[utf8Entries++] = off;
                 }
                 off += type.byteLength(bytes, off);
             }
-            cpOff = off;
-            this.constantPoolEndOffset = cpOff;
+            this.constantPoolEndOffset = off;
+            this.constantPoolUtf8EntryOffsets = Arrays.copyOf(utf8EntryOffsets, utf8Entries);
         }
-        this.accessFlags = u16(bytes, cpOff + Offsets.pastCpAccessFlagsU16);
-        this.thisClassIndex = u16(bytes, cpOff + Offsets.pastCpThisClassU16);
-        this.superClassIndex = u16(bytes, cpOff + Offsets.pastCpSuperClassU16);
-        this.interfacesCount = u16(bytes, cpOff + Offsets.pastCpInterfacesCountU16);
-        this.interfaceIndices = new int[this.interfacesCount];
-        List<String> interfaceNames = new ArrayList<>(this.interfacesCount);
+        this.accessFlags = u16(bytes, this.constantPoolEndOffset + Offsets.pastCpAccessFlagsU16);
+        this.thisClassIndex = u16(bytes, this.constantPoolEndOffset + Offsets.pastCpThisClassU16);
+        this.superClassIndex = u16(bytes, this.constantPoolEndOffset + Offsets.pastCpSuperClassU16);
+        this.interfacesCount = u16(bytes, this.constantPoolEndOffset + Offsets.pastCpInterfacesCountU16);
 
         // Parse this&super names
         if (constantPoolEntryTypes[thisClassIndex - 1] != ConstantPoolEntryTypes.Class) {
@@ -91,10 +98,10 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
             // Should only be true for this==java/lang/Object
             this.binarySuperName = null;
         } else {
-            final int superNameIndex = u16(bytes, constantPoolEntryOffsets[superClassIndex - 1] + 1);
             if (constantPoolEntryTypes[superClassIndex - 1] != ConstantPoolEntryTypes.Class) {
                 throw new IllegalArgumentException("Super class index is not a class ref");
             }
+            final int superNameIndex = u16(bytes, constantPoolEntryOffsets[superClassIndex - 1] + 1);
             if (constantPoolEntryTypes[superNameIndex - 1] != ConstantPoolEntryTypes.Utf8) {
                 throw new IllegalArgumentException("Super class index does not point to a UTF8 entry");
             }
@@ -102,8 +109,10 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
         }
 
         // Parse interface names
+        final ArrayList<String> interfaceNames = new ArrayList<>(this.interfacesCount);
+        this.interfaceIndices = new int[this.interfacesCount];
         for (int i = 0; i < this.interfacesCount; i++) {
-            final int interfaceOffset = cpOff + Offsets.pastCpInterfacesList + i * 2;
+            final int interfaceOffset = this.constantPoolEndOffset + Offsets.pastCpInterfacesList + i * 2;
             final int interfaceIndex = u16(bytes, interfaceOffset);
             if (constantPoolEntryTypes[interfaceIndex - 1] != ConstantPoolEntryTypes.Class) {
                 throw new IllegalArgumentException("Interface " + i + " index is not a class ref");
@@ -309,77 +318,49 @@ public final class ClassHeaderMetadata implements FastClassAccessor {
     }
 
     /**
-     * Searches for a sub"string" (byte array) in a longer byte array.
-     * @param classBytes The long byte string to search in.
-     * @param substrings The list of substrings to search for.
-     * @return If the substring was found somewhere in the long string.
+     * Searches for byte patterns in the constant pool.
+     * @param matcher A configured byte matcher with patterns to search for.
+     * @return {@code true} if there is a match for at least one constant pool entry.
      */
-    public static boolean hasSubstrings(final byte @Nullable [] classBytes, final byte @NotNull [][] substrings) {
-        if (classBytes == null || classBytes.length < Offsets.constantPoolStart) {
-            return false;
-        }
+    public boolean matchesBytes(final BytePatternMatcher matcher) {
+        for (final int offset : constantPoolUtf8EntryOffsets) {
+            // first byte is entry type, second and third bytes are length
+            final int length = u16(classBytes, offset + 1);
+            final int start = offset + 3;
 
-        // Loop through each entry in the constant pool, getting the size and content before jumping to the next.
-        // Strings get scanned for the searched constants, and if found result in an early exit.
-        final int constantsCount = u16(classBytes, Offsets.constantPoolCountU16);
-        int offset = Offsets.constantPoolStart;
-        for (int i = 1; i < constantsCount; ++i) {
-            ConstantPoolEntryTypes type = ConstantPoolEntryTypes.parse(classBytes, offset);
-            int size;
-
-            switch (type) {
-                case Utf8: {
-                    final int strLen = u16(classBytes, offset + 1);
-                    final int start = offset + 3;
-                    size = strLen + 3;
-
-                    for (byte[] bytes : substrings) {
-                        if (strLen < bytes.length) {
-                            continue;
-                        }
-
-                        byte first = bytes[0];
-                        int end = start + strLen - bytes.length;
-                        for (int j = start; j <= end; j++) {
-                            if (classBytes[j] != first) continue;
-                            int k = 1;
-                            while (k < bytes.length && classBytes[j + k] == bytes[k]) k++;
-                            if (k == bytes.length) return true;
-                        }
-                    }
-                    break;
-                }
-                case Long:
-                case Double: {
-                    // Longs and Doubles take up 2 constant pool indices
-                    ++i;
-                    size = type.maybeByteLength + 1;
-                    break;
-                }
-                default: {
-                    size = type.maybeByteLength + 1;
-                    break;
-                }
+            if (matcher.matches(classBytes, start, length)) {
+                return true;
             }
-
-            offset += size;
         }
 
         return false;
     }
 
-    /**
-     * Searches for a sub"string" (byte array) in a longer byte array.
-     * @param classBytes The long byte string to search in.
-     * @param substring The substring to search for.
-     * @return If the substring was found somewhere in the long string.
-     */
-    public static boolean hasSubstring(final byte @Nullable [] classBytes, final byte @NotNull [] substring) {
-        return hasSubstrings(classBytes, new byte[][] {substring});
-    }
-
     public boolean hasInvokeDynamicEntry() {
         return hasInvokeDynamicEntry;
+    }
+
+    /** @deprecated This method is very slow, use {@link #matchesBytes} instead */
+    @Deprecated
+    public static boolean hasSubstring(final byte @Nullable [] classBytes, final byte @NotNull [] substring) {
+        if (classBytes == null) {
+            return false;
+        }
+        final int classLen = classBytes.length;
+        final int subLen = substring.length;
+        if (classLen < subLen) {
+            return false;
+        }
+        outer:
+        for (int startPos = 0; startPos + subLen - 1 < classLen; startPos++) {
+            for (int i = 0; i < subLen; i++) {
+                if (classBytes[startPos + i] != substring[i]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmTypeTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmTypeTransformer.java
@@ -56,7 +56,7 @@ public class AsmTypeTransformer implements RfbClassTransformer {
             return false;
         }
 
-        return metadata.matchesBytes(methodDescMatcher);
+        return metadata.matchesBytes(classNode.getOriginalBytes(), methodDescMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmTypeTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmTypeTransformer.java
@@ -1,10 +1,10 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
-import java.nio.charset.StandardCharsets;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import org.intellij.lang.annotations.Pattern;
@@ -23,7 +23,8 @@ public class AsmTypeTransformer implements RfbClassTransformer {
     /** Attribute to set to "true" on a JAR to skip class transforms from this transformer entirely */
     public static final Attributes.Name MANIFEST_SAFE_ATTRIBUTE = new Attributes.Name("Has-Safe-AsmGetTypeUsage");
 
-    private static final byte[] quickScan = "org/objectweb/asm/Type".getBytes(StandardCharsets.UTF_8);
+    private static final BytePatternMatcher methodDescMatcher =
+            new BytePatternMatcher("(Ljava/lang/String;)Lorg/objectweb/asm/Type;", BytePatternMatcher.Mode.Equals);
 
     @Pattern("[a-z0-9-]+")
     @Override
@@ -44,13 +45,18 @@ public class AsmTypeTransformer implements RfbClassTransformer {
         if (manifest != null && "true".equals(manifest.getMainAttributes().getValue(MANIFEST_SAFE_ATTRIBUTE))) {
             return false;
         }
-        // Assume classes for java 9+ were tested against a newer asm.
-        if (classNode.getOriginalMetadata() != null && classNode.getOriginalMetadata().majorVersion >= Opcodes.V9) {
+
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        if (metadata == null) {
             return false;
         }
 
-        final byte[] original = classNode.getOriginalBytes();
-        return ClassHeaderMetadata.hasSubstring(original, quickScan);
+        // Assume classes for java 9+ were tested against a newer asm.
+        if (metadata.majorVersion >= Opcodes.V9) {
+            return false;
+        }
+
+        return metadata.matchesBytes(methodDescMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmUpgradeTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmUpgradeTransformer.java
@@ -1,12 +1,12 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.gtnewhorizons.retrofuturabootstrap.asm.UpgradedTreeNodes;
 import com.gtnewhorizons.retrofuturabootstrap.asm.UpgradedVisitors;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.Manifest;
@@ -26,9 +26,8 @@ import org.objectweb.asm.tree.TypeInsnNode;
  * This allows those transformers to work on newer classes.
  */
 public class AsmUpgradeTransformer implements RfbClassTransformer {
-    private static final byte[] quickScan = "org/objectweb/asm".getBytes(StandardCharsets.UTF_8);
-
     private final Map<String, String> upgradeMap = new HashMap<>();
+    private final BytePatternMatcher asmClassMatcher;
 
     public AsmUpgradeTransformer() {
         for (Class<?> visitor : UpgradedVisitors.ALL_VISITORS) {
@@ -37,6 +36,9 @@ public class AsmUpgradeTransformer implements RfbClassTransformer {
         for (Class<?> visitor : UpgradedTreeNodes.ALL_NODES) {
             upgradeMap.put(Type.getInternalName(visitor.getSuperclass()), Type.getInternalName(visitor));
         }
+
+        asmClassMatcher =
+                new BytePatternMatcher(upgradeMap.keySet().toArray(new String[0]), BytePatternMatcher.Mode.Equals);
     }
 
     @Pattern("[a-z0-9-]+")
@@ -56,8 +58,8 @@ public class AsmUpgradeTransformer implements RfbClassTransformer {
             return false;
         }
 
-        final byte[] original = classNode.getOriginalBytes();
-        return ClassHeaderMetadata.hasSubstring(original, quickScan);
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        return metadata != null && metadata.matchesBytes(asmClassMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmUpgradeTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/AsmUpgradeTransformer.java
@@ -59,7 +59,7 @@ public class AsmUpgradeTransformer implements RfbClassTransformer {
         }
 
         final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
-        return metadata != null && metadata.matchesBytes(asmClassMatcher);
+        return metadata != null && metadata.matchesBytes(classNode.getOriginalBytes(), asmClassMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/DeprecatedRedirectTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/DeprecatedRedirectTransformer.java
@@ -1,11 +1,11 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
 import com.gtnewhorizons.retrofuturabootstrap.SharedConfig;
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
@@ -26,14 +26,14 @@ import org.objectweb.asm.tree.MethodNode;
  */
 public class DeprecatedRedirectTransformer extends Remapper implements RfbClassTransformer {
 
-    public DeprecatedRedirectTransformer() {
-        excludedPackages = Stream.concat(Arrays.stream(fromPrefixes), Arrays.stream(toPrefixes))
-                .map(s -> s.replace('/', '.'))
-                .toArray(String[]::new);
-        quickScans = Arrays.stream(fromPrefixes)
-                .map(s -> s.getBytes(StandardCharsets.UTF_8))
-                .toArray(byte[][]::new);
-    }
+    final String[] fromPrefixes = new String[] {"java/lang/Compiler", "java/lang/SecurityManager"};
+    final String[] toPrefixes = new String[] {
+        "com/gtnewhorizons/retrofuturabootstrap/asm/DummyCompiler",
+        "com/gtnewhorizons/retrofuturabootstrap/SecurityManager"
+    };
+
+    final BytePatternMatcher deprecatedClassMatcher =
+            new BytePatternMatcher(fromPrefixes, BytePatternMatcher.Mode.Contains);
 
     @Pattern("[a-z0-9-]+")
     @Override
@@ -43,16 +43,10 @@ public class DeprecatedRedirectTransformer extends Remapper implements RfbClassT
 
     @Override
     public @NotNull String @Nullable [] additionalExclusions() {
-        return excludedPackages;
+        return Stream.concat(Arrays.stream(fromPrefixes), Arrays.stream(toPrefixes))
+                .map(s -> s.replace('/', '.'))
+                .toArray(String[]::new);
     }
-
-    final String[] fromPrefixes = new String[] {"java/lang/Compiler", "java/lang/SecurityManager"};
-    final String[] toPrefixes = new String[] {
-        "com/gtnewhorizons/retrofuturabootstrap/asm/DummyCompiler",
-        "com/gtnewhorizons/retrofuturabootstrap/SecurityManager"
-    };
-    final byte[][] quickScans;
-    final String[] excludedPackages;
 
     @Override
     public boolean shouldTransformClass(
@@ -64,22 +58,16 @@ public class DeprecatedRedirectTransformer extends Remapper implements RfbClassT
         if (!classNode.isPresent()) {
             return false;
         }
-        final int classVersion;
-        if (classNode.getOriginalMetadata() != null) {
-            classVersion = classNode.getOriginalMetadata().majorVersion;
-        } else {
-            classVersion = 8;
-        }
 
-        if (classVersion >= Opcodes.V21) {
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        if (metadata == null) {
+            return false;
+        }
+        if (metadata.majorVersion >= Opcodes.V21) {
             return false;
         }
 
-        final byte[] original = classNode.getOriginalBytes();
-        if (original == null) {
-            return false;
-        }
-        return ClassHeaderMetadata.hasSubstrings(original, quickScans);
+        return metadata.matchesBytes(deprecatedClassMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/DeprecatedRedirectTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/DeprecatedRedirectTransformer.java
@@ -67,7 +67,7 @@ public class DeprecatedRedirectTransformer extends Remapper implements RfbClassT
             return false;
         }
 
-        return metadata.matchesBytes(deprecatedClassMatcher);
+        return metadata.matchesBytes(classNode.getOriginalBytes(), deprecatedClassMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/SafeClassWriterTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/SafeClassWriterTransformer.java
@@ -1,11 +1,11 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.gtnewhorizons.retrofuturabootstrap.asm.SafeAsmClassWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import org.intellij.lang.annotations.Pattern;
@@ -26,15 +26,17 @@ public class SafeClassWriterTransformer implements RfbClassTransformer {
     /** Attribute to set to "true" on a JAR to skip class transforms from this transformer entirely */
     public static final Attributes.Name MANIFEST_SAFE_ATTRIBUTE = new Attributes.Name("Has-Safe-ClassWriters");
 
+    final String CLASS_WRITER_NAME = ClassWriter.class.getName().replace('.', '/');
+    final String SAFE_WRITER_NAME = SafeAsmClassWriter.class.getName().replace('.', '/');
+
+    final BytePatternMatcher classWriterMatcher =
+            new BytePatternMatcher(CLASS_WRITER_NAME, BytePatternMatcher.Mode.Equals);
+
     @Pattern("[a-z0-9-]+")
     @Override
     public @NotNull String id() {
         return "safe-class-writer";
     }
-
-    final String CLASS_WRITER_NAME = ClassWriter.class.getName().replace('.', '/');
-    final byte[] CLASS_WRITER_BYTES = CLASS_WRITER_NAME.getBytes(StandardCharsets.UTF_8);
-    final String SAFE_WRITER_NAME = SafeAsmClassWriter.class.getName().replace('.', '/');
 
     @Override
     public boolean shouldTransformClass(
@@ -50,7 +52,8 @@ public class SafeClassWriterTransformer implements RfbClassTransformer {
             return false;
         }
 
-        return ClassHeaderMetadata.hasSubstring(classNode.getOriginalBytes(), CLASS_WRITER_BYTES);
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        return metadata != null && metadata.matchesBytes(classWriterMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/SafeClassWriterTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/SafeClassWriterTransformer.java
@@ -53,7 +53,7 @@ public class SafeClassWriterTransformer implements RfbClassTransformer {
         }
 
         final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
-        return metadata != null && metadata.matchesBytes(classWriterMatcher);
+        return metadata != null && metadata.matchesBytes(classNode.getOriginalBytes(), classWriterMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
@@ -73,7 +73,7 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
         }
 
         final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
-        return metadata != null && metadata.matchesBytes(reflectionMatcher);
+        return metadata != null && metadata.matchesBytes(classNode.getOriginalBytes(), reflectionMatcher);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UnsafeReflectionTransformer.java
@@ -1,12 +1,12 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.gtnewhorizons.retrofuturabootstrap.asm.UnsafeReflectionRedirector;
 import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -28,34 +28,34 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
     /** Attribute to set to "true" on a JAR to skip class transforms from this transformer entirely */
     public static final Attributes.Name MANIFEST_SAFE_ATTRIBUTE = new Attributes.Name("Has-Safe-Reflection");
 
+    final String CLASS_NAME = Type.getInternalName(Class.class);
+    final String FIELD_NAME = Type.getInternalName(Field.class);
+    final String REDIRECTION_NAME = Type.getInternalName(UnsafeReflectionRedirector.class);
+
+    final String CLASS_GET_DECLARED_FIELD_DESC = "(Ljava/lang/String;)Ljava/lang/reflect/Field;";
+    final String CLASS_GET_DECLARED_FIELDS_DESC = "()[Ljava/lang/reflect/Field;";
+
+    // Redirect set methods with a type that can be coerced to int, and get methods with types int can be coerced to
+    final HashSet<String> REDIRECT_FIELD_METHODS = new HashSet<>(Arrays.asList(
+            "setInt(Ljava/lang/Object;I)V",
+            "setByte(Ljava/lang/Object;B)V",
+            "setShort(Ljava/lang/Object;S)V",
+            "setChar(Ljava/lang/Object;C)V",
+            "getInt(Ljava/lang/Object;)I",
+            "getLong(Ljava/lang/Object;)J",
+            "getFloat(Ljava/lang/Object;)F",
+            "getDouble(Ljava/lang/Object;)D",
+            "set(Ljava/lang/Object;Ljava/lang/Object;)V",
+            "get(Ljava/lang/Object;)Ljava/lang/Object"));
+
+    final BytePatternMatcher reflectionMatcher = new BytePatternMatcher(
+            new String[] {CLASS_GET_DECLARED_FIELD_DESC, CLASS_GET_DECLARED_FIELDS_DESC, FIELD_NAME},
+            BytePatternMatcher.Mode.Equals);
+
     @Pattern("[a-z0-9-]+")
     @Override
     public @NotNull String id() {
         return "unsafe-reflection";
-    }
-
-    final String CLASS_NAME = Type.getInternalName(Class.class);
-    final byte[] CLASS_NAME_BYTES = CLASS_NAME.getBytes(StandardCharsets.UTF_8);
-    final String FIELD_NAME = Type.getInternalName(Field.class);
-    final byte[] FIELD_NAME_BYTES = FIELD_NAME.getBytes(StandardCharsets.UTF_8);
-    final String REDIRECTION_NAME = Type.getInternalName(UnsafeReflectionRedirector.class);
-    final Set<String> REDIRECT_FIELD_METHODS = new HashSet<>();
-
-    final byte[][] quickScans = new byte[][] {CLASS_NAME_BYTES, FIELD_NAME_BYTES};
-
-    {
-        // Redirect set methods with a type that can be coerced to int, and get methods with types int can be coerced to
-        REDIRECT_FIELD_METHODS.addAll(Arrays.asList(
-                "setInt(Ljava/lang/Object;I)V",
-                "setByte(Ljava/lang/Object;B)V",
-                "setShort(Ljava/lang/Object;S)V",
-                "setChar(Ljava/lang/Object;C)V",
-                "getInt(Ljava/lang/Object;)I",
-                "getLong(Ljava/lang/Object;)J",
-                "getFloat(Ljava/lang/Object;)F",
-                "getDouble(Ljava/lang/Object;)D",
-                "set(Ljava/lang/Object;Ljava/lang/Object;)V",
-                "get(Ljava/lang/Object;)Ljava/lang/Object"));
     }
 
     @Override
@@ -72,7 +72,8 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
             return false;
         }
 
-        return ClassHeaderMetadata.hasSubstrings(classNode.getOriginalBytes(), quickScans);
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        return metadata != null && metadata.matchesBytes(reflectionMatcher);
     }
 
     @Override
@@ -95,14 +96,14 @@ public class UnsafeReflectionTransformer implements RfbClassTransformer {
                     final MethodInsnNode insn = (MethodInsnNode) rawInsn;
                     if (insn.owner.equals(CLASS_NAME)
                             && insn.name.equals("getDeclaredField")
-                            && insn.desc.equals("(Ljava/lang/String;)Ljava/lang/reflect/Field;")) {
+                            && insn.desc.equals(CLASS_GET_DECLARED_FIELD_DESC)) {
                         // getDeclaredField(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/reflect/Field;
                         insn.setOpcode(Opcodes.INVOKESTATIC);
                         insn.owner = REDIRECTION_NAME;
                         insn.desc = "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/reflect/Field;";
                     } else if (insn.owner.equals(CLASS_NAME)
                             && insn.name.equals("getDeclaredFields")
-                            && insn.desc.equals("()[Ljava/lang/reflect/Field;")) {
+                            && insn.desc.equals(CLASS_GET_DECLARED_FIELDS_DESC)) {
                         // getDeclaredFields(Ljava/lang/Class;)[Ljava/lang/reflect/Field;
                         insn.setOpcode(Opcodes.INVOKESTATIC);
                         insn.owner = REDIRECTION_NAME;

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UuidTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UuidTransformer.java
@@ -1,11 +1,11 @@
 package com.gtnewhorizons.rfbplugins.compat.transformers;
 
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.gtnewhorizons.retrofuturabootstrap.asm.UuidStringConstructor;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -26,15 +26,18 @@ public class UuidTransformer implements RfbClassTransformer {
     /** Attribute to set to "true" on a JAR to skip class transforms from this transformer entirely */
     public static final Attributes.Name MANIFEST_SAFE_ATTRIBUTE = new Attributes.Name("Has-Safe-UUID");
 
+    final String UUID_NAME = Type.getInternalName(UUID.class);
+    final String UUID_FROM_STRING_DESC = "(Ljava/lang/String;)Ljava/util/UUID;";
+    final String REDIRECTION_NAME = Type.getInternalName(UuidStringConstructor.class);
+
+    final BytePatternMatcher fromStringMethodMatcher =
+            new BytePatternMatcher(UUID_FROM_STRING_DESC, BytePatternMatcher.Mode.Equals);
+
     @Pattern("[a-z0-9-]+")
     @Override
     public @NotNull String id() {
         return "uuid";
     }
-
-    final String UUID_NAME = Type.getInternalName(UUID.class);
-    final byte[] UUID_NAME_BYTES = UUID_NAME.getBytes(StandardCharsets.UTF_8);
-    final String REDIRECTION_NAME = Type.getInternalName(UuidStringConstructor.class);
 
     @Override
     public boolean shouldTransformClass(
@@ -49,11 +52,16 @@ public class UuidTransformer implements RfbClassTransformer {
         if (manifest != null && "true".equals(manifest.getMainAttributes().getValue(MANIFEST_SAFE_ATTRIBUTE))) {
             return false;
         }
-        if (classNode.getOriginalMetadata() != null && classNode.getOriginalMetadata().majorVersion >= Opcodes.V9) {
+
+        final ClassHeaderMetadata metadata = classNode.getOriginalMetadata();
+        if (metadata == null) {
+            return false;
+        }
+        if (metadata.majorVersion >= Opcodes.V9) {
             return false;
         }
 
-        return ClassHeaderMetadata.hasSubstring(classNode.getOriginalBytes(), UUID_NAME_BYTES);
+        return metadata.matchesBytes(fromStringMethodMatcher);
     }
 
     @Override
@@ -76,7 +84,7 @@ public class UuidTransformer implements RfbClassTransformer {
                     final MethodInsnNode insn = (MethodInsnNode) rawInsn;
                     if (insn.owner.equals(UUID_NAME)
                             && insn.name.equals("fromString")
-                            && insn.desc.equals("(Ljava/lang/String;)Ljava/util/UUID;")) {
+                            && insn.desc.equals(UUID_FROM_STRING_DESC)) {
                         insn.owner = REDIRECTION_NAME;
                     }
                 }

--- a/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UuidTransformer.java
+++ b/src/main/java/com/gtnewhorizons/rfbplugins/compat/transformers/UuidTransformer.java
@@ -61,7 +61,7 @@ public class UuidTransformer implements RfbClassTransformer {
             return false;
         }
 
-        return metadata.matchesBytes(fromStringMethodMatcher);
+        return metadata.matchesBytes(classNode.getOriginalBytes(), fromStringMethodMatcher);
     }
 
     @Override

--- a/src/test/java/com/gtnewhorizons/retrofuturabootstrap/test/ClassHeaderMetadataTest.java
+++ b/src/test/java/com/gtnewhorizons/retrofuturabootstrap/test/ClassHeaderMetadataTest.java
@@ -1,29 +1,60 @@
 package com.gtnewhorizons.retrofuturabootstrap.test;
 
+import static com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher.Mode.Contains;
+import static com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher.Mode.Equals;
+import static com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher.Mode.StartsWith;
+
+import com.gtnewhorizons.retrofuturabootstrap.api.BytePatternMatcher;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ClassHeaderMetadataTest {
 
-    static byte[] bytes(String s) {
-        return s.getBytes(StandardCharsets.UTF_8);
+    @Test
+    void matchesBytesContains() throws IOException {
+        byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
+        ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
+
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("lwjgl", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", Contains)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", Contains)));
     }
 
     @Test
-    void hasSubstring() throws IOException {
+    void matchesBytesEquals() throws IOException {
         byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
+        ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
 
-        Assertions.assertFalse(ClassHeaderMetadata.hasSubstring(classBytes, bytes("org/whatever")));
-        Assertions.assertTrue(ClassHeaderMetadata.hasSubstring(classBytes, bytes("org")));
-        Assertions.assertTrue(ClassHeaderMetadata.hasSubstring(classBytes, bytes("lwjgl")));
-        Assertions.assertTrue(ClassHeaderMetadata.hasSubstring(classBytes, bytes("org/lwjgl/")));
-        Assertions.assertTrue(ClassHeaderMetadata.hasSubstring(classBytes, bytes("org/lwjgl/opengl/GL11")));
-        Assertions.assertFalse(ClassHeaderMetadata.hasSubstring(classBytes, bytes("org/lwjgl/opengl/GL11/meh")));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("lwjgl", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/", Equals)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", Equals)));
+    }
+
+    @Test
+    void matchesBytesStartsWith() throws IOException {
+        byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
+        ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
+
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org", StartsWith)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("lwjgl", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", StartsWith)));
+        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", StartsWith)));
+    }
+
+    private static BytePatternMatcher matcher(String str, BytePatternMatcher.Mode mode) {
+        return new BytePatternMatcher(str, mode);
     }
 
     private static byte[] stubClassBytes(String stubPoolConstant) throws IOException {

--- a/src/test/java/com/gtnewhorizons/retrofuturabootstrap/test/ClassHeaderMetadataTest.java
+++ b/src/test/java/com/gtnewhorizons/retrofuturabootstrap/test/ClassHeaderMetadataTest.java
@@ -19,12 +19,12 @@ public class ClassHeaderMetadataTest {
         byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
         ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
 
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", Contains)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org", Contains)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("lwjgl", Contains)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/", Contains)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", Contains)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", Contains)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/whatever", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("lwjgl", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org/lwjgl/", Contains)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11", Contains)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11/meh", Contains)));
     }
 
     @Test
@@ -32,12 +32,12 @@ public class ClassHeaderMetadataTest {
         byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
         ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
 
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", Equals)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org", Equals)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("lwjgl", Equals)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/", Equals)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", Equals)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/whatever", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("lwjgl", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/lwjgl/", Equals)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11", Equals)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11/meh", Equals)));
     }
 
     @Test
@@ -45,12 +45,12 @@ public class ClassHeaderMetadataTest {
         byte[] classBytes = stubClassBytes("org/lwjgl/opengl/GL11");
         ClassHeaderMetadata metadata = new ClassHeaderMetadata(classBytes);
 
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/whatever", StartsWith)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org", StartsWith)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("lwjgl", StartsWith)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/", StartsWith)));
-        Assertions.assertTrue(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11", StartsWith)));
-        Assertions.assertFalse(metadata.matchesBytes(matcher("org/lwjgl/opengl/GL11/meh", StartsWith)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/whatever", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org", StartsWith)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("lwjgl", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org/lwjgl/", StartsWith)));
+        Assertions.assertTrue(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11", StartsWith)));
+        Assertions.assertFalse(metadata.matchesBytes(classBytes, matcher("org/lwjgl/opengl/GL11/meh", StartsWith)));
     }
 
     private static BytePatternMatcher matcher(String str, BytePatternMatcher.Mode mode) {


### PR DESCRIPTION
This PR is a continuation of #19. Right after it, I started wondering what else could still be optimized in the RFB flow, and to my surprise, the answer was... `shouldTransformClass` again

lwjgl3ify pr: GTNewHorizons/lwjgl3ify/pull/331

| Metric | Before | After | Win |
|-|-|-|-|
| runRfbTransformers | 2193ms | 1283ms | 910ms |
| hasSubstring -> matchesBytes | 840.5ms | 263.8ms | 576.7ms |
| UnsafeReflectionTransformer.transformClass | 184.9ms | 22.2ms | 162.7ms |

How to read this table:
- We're 71% faster! It's even a bit more than the performance jump of my initial PR #19
- `runRfbTransformers` is the overall RFB transforming time
- `hasSubstring -> matchesBytes` is part of `runRfbTransformers` time
- `UnsafeReflectionTransformer.transformClass` shows that not only `shouldTransformClass` has been optimized: in some transformers this method is now more precise, so we're hitting slow `transformClass` much less. Also a part of `runRfbTransformers` time, but 

Note: these measurements may seem considerably different from the parent PR #20. There are a few reasons for that:
1) i've switched to MacBook M5 from M1, so I have faster CPU & SSD and more RAM
2) Measurements in mentioned PR were made before I made a few new optimization PRs in RFB and Angelica (though the After result includes them already)
3) this PR doesn't include `computeBytes` time reduction optimization (by adding `transformClassIfNeeded` and marking transformations as non-dirty when it returns false)

## How?

### 1. Exact matching

Before: `hasSubstring` was always searching for a substring in every CP UTF8 entry

After: In reality, we don't need substring searching in every case. `BytePatternMatcher` allows to choose between `Contains `, `Equals`, and `StartsWith` modes. Luckily for us, `Equals` is often an appropriate option

### 2. Reuse already calculated CP entry offsets

Before: for every transformer and every class `hasSubstring` was fully iterating over `classBytes` and parsing CP entry tags

After:
a) we're collecting an offset array only once per class and sharing them between all RFB transformers
b) we're collecting specifically an offset array of UTF8 entries, which on average contains only 50% of all CP entries

So in `matchesBytes` we're iterating over a much shorter array without needing to perform many redundant operations to filter out non-utf8 entries

### 3. Bucketing by first char

`BytePatternMatcher` on instantiation prepares a bucket array, which points at a list of matched patterns by their first char. It makes matching faster if we have more than one pattern, which is often the case. Having many specific `Equals` patterns in one matcher now is much more convenient than having one broader pattern

### 4. Considering pattern lengths

On `BytePatternMatcher` instantiation we calculate the minimum pattern length, so we can exit early if the utf8 entry is shorter than any of the patterns

Also we sort patterns by their length so we can exit early from the loop when a pattern is larger than the utf8 entry because we know all the next patterns are going to be only larger

### 5. Comparing strings from the end

Patterns often start from a common enough prefix like `com/`, `net/`, `java/`. By comparing from the end of the pattern we can stop string scanning earlier