### PR TITLE
Respect readerOptions in ClassNodeHandle

### DIFF
--- a/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassNodeHandle.java
+++ b/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/ClassNodeHandle.java
@@ -39,7 +39,7 @@ public final class ClassNodeHandle {
         }
         this.originalMetadata = originalMetadata;
         this.accessor = originalMetadata;
-        this.readerOptions = 0;
+        this.readerOptions = readerOptions;
     }
 
     /** Gets the original pre-transformer-phase bytes of the class. */


### PR DESCRIPTION
While skimming through RetroFuturaBootstrap's code, I noticed that custom `readerOptions` passed to `ClassNodeHandle` were (most-likely unintentionally) ignored.

This change should not affect existing behavior as RFB internally uses the constructor which supplies `0` anways, and it seems like RFB is the only thing that actually constructs `ClassNodeHandle`'s. However, if another developer tries constructing a handle for whatever reason with custom reader options, this change ensures that their options are respected.